### PR TITLE
feat(herdr): add herdr config with terminal theme

### DIFF
--- a/herder/.config/herder/config.toml
+++ b/herder/.config/herder/config.toml
@@ -1,0 +1,2 @@
+[theme]
+name = "terminal"

--- a/install.sh
+++ b/install.sh
@@ -58,6 +58,8 @@ brew install pnpm
 brew install glow
 # install go lang for regols
 brew install golang
+# install herdr terminal workspace manager for AI coding agents
+brew install herdr
 
 # macOS only
 if [[ "$OSTYPE" == "darwin"* ]]; then
@@ -78,6 +80,7 @@ stow --restow ghostty
 stow --restow opencode
 stow --restow amp
 stow --restow copilot
+stow --restow herder
 
 # macOS only
 if [[ "$OSTYPE" == "darwin"* ]]; then


### PR DESCRIPTION
## What

- Add `herder/.config/herder/config.toml` with `name = "terminal"` theme, which inherits the outer terminal's color palette
- Add `brew install herdr` to `install.sh`
- Add `stow --restow herder` to the restow section

## Config

```toml
[theme]
name = "terminal"
```

No dynamic sync mechanism needed — Herdr's `terminal` theme picks up Ghostty's current colors on every launch.