### PR TITLE
fix(opencode): use $HOME variable in external_directory permission

### DIFF
--- a/.opencode/opencode.json
+++ b/.opencode/opencode.json
@@ -61,8 +61,8 @@
       "*": "ask"
     },
     "external_directory": {
-      "/Users/rickypowell/.herdr/**": "allow",
-      "/Users/rickypowell/.herdr/worktrees/*": "allow",
+      "$HOME/.herdr/**": "allow",
+      "$HOME/.herdr/worktrees/*": "allow",
       "*": "ask"
     }
   }

--- a/.opencode/opencode.json
+++ b/.opencode/opencode.json
@@ -61,7 +61,8 @@
       "*": "ask"
     },
     "external_directory": {
-      "~/.herdr/**": "allow",
+      "/Users/rickypowell/.herdr/**": "allow",
+      "/Users/rickypowell/.herdr/worktrees/*": "allow",
       "*": "ask"
     }
   }

--- a/.opencode/opencode.json
+++ b/.opencode/opencode.json
@@ -62,7 +62,6 @@
     },
     "external_directory": {
       "$HOME/.herdr/**": "allow",
-      "$HOME/.herdr/worktrees/*": "allow",
       "*": "ask"
     }
   }


### PR DESCRIPTION
## Problem

The opencode permission pattern `~/.herdr/**` never matched `/Users/rickypowell/.herdr/worktrees/eighty-twenty` because JSON config does not expand `~`.

## Fix

Replace the hardcoded username path with `$HOME`, which opencode supports natively in permission patterns.

```diff
 "external_directory": {
-  "~/.herdr/**": "allow",
+  "$HOME/.herdr/**": "allow",
   "*": "ask"
 }
```

- Uses opencode built-in `$HOME` expansion (no hardcoded username)
- Single line — `$HOME/.herdr/**` already covers `worktrees/*`