### PR TITLE
fix(opencode): move bash wildcard rule first to fix permission ordering

### DIFF
--- a/opencode/.config/opencode/opencode.json
+++ b/opencode/.config/opencode/opencode.json
@@ -38,6 +38,7 @@
         "lsp": "allow",
         "read": "allow",
         "bash": {
+            "*": "ask",
             "awk *": "allow",
             "brew list *": "allow",
             "bun *": "allow",
@@ -73,8 +74,7 @@
             "swiftc *": "allow",
             "git push *": "ask",
             "npm install *": "ask",
-            "rm *": "ask",
-            "*": "ask"
+            "rm *": "ask"
         },
         "webfetch": "allow"
     },


### PR DESCRIPTION
opencode evaluates bash permission rules in order with last-match-wins semantics.

The catch-all `"*": "ask"` was at the end of the bash permission object, which caused it to override all specific `allow` rules above it.

**Fix:** Move `"*": "ask"` to the first position in the bash permission object, so specific allow rules (git, xcodebuild, etc.) match before the wildcard catch-all.