### PR TITLE
fix(opencode): change bash permission default from ask to allow

### DIFF
--- a/opencode/.config/opencode/opencode.json
+++ b/opencode/.config/opencode/opencode.json
@@ -38,7 +38,7 @@
         "lsp": "allow",
         "read": "allow",
         "bash": {
-            "*": "ask",
+            "*": "allow",
             "awk *": "allow",
             "brew list *": "allow",
             "bun *": "allow",

--- a/opencode/.config/opencode/opencode.json
+++ b/opencode/.config/opencode/opencode.json
@@ -58,6 +58,7 @@
             "jq *": "allow",
             "ls *": "allow",
             "mkdir *": "allow",
+            "cd *": "ask",
             "mv *": "allow",
             "node *": "allow",
             "npm *": "allow",


### PR DESCRIPTION
Change the bash permission catch-all from `"*"`: `ask` to `"*"`: `allow`.

The catch-all rule was causing thousands of permission prompts for bash commands even when specific commands were set to `allow`. This is a known issue (#41846) where project-level opencode.json overrides UI settings.

With this change, all bash commands auto-allow except the explicitly listed ones that need approval:
- `git push *`
- `npm install *`
- `rm *`