### PR TITLE
chore(opencode): use build mode by default for Herdr worktrees

### DIFF
--- a/opencode/.config/opencode/opencode.json
+++ b/opencode/.config/opencode/opencode.json
@@ -3,6 +3,9 @@
     "autoupdate": true,
     "default_agent": "build",
     "small_model": "lmstudio/laguna-xs-2.1-nvfp4-mlx",
+    "instructions": [
+        "rules/herdr-agent-work.md"
+    ],
     "plugin": [
         "./plugins/osascript-notifications.js"
     ],

--- a/opencode/.config/opencode/opencode.json
+++ b/opencode/.config/opencode/opencode.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://opencode.ai/config.json",
     "autoupdate": true,
-    "default_agent": "plan",
+    "default_agent": "build",
     "small_model": "lmstudio/laguna-xs-2.1-nvfp4-mlx",
     "plugin": [
         "./plugins/osascript-notifications.js"

--- a/opencode/.config/opencode/rules/herdr-agent-work.md
+++ b/opencode/.config/opencode/rules/herdr-agent-work.md
@@ -1,0 +1,31 @@
+# Herdr Agent Work Rule
+
+When `HERDR_ENV=1`, you are running inside a Herdr-managed terminal.
+
+## Rule: Delegate work to Herdr agents
+
+Never make file changes, run git commands, or perform work manually. Always start an agent in a Herdr pane and let it do the work.
+
+## Workflow
+
+1. **Check**: If `HERDR_ENV=1`, you must use the agent workflow below.
+2. **Create worktree** (if needed): `herdr worktree create --label "<label>" --branch "<branch>" --no-focus`
+3. **Split pane**: `herdr pane split --current --direction right --cwd "$PWD" --no-focus`
+4. **Start agent**: `herdr agent start <name> --kind opencode --pane <pane-id>`
+5. **Prompt agent**: `herdr agent prompt <name> "<task>" --wait --timeout 120000`
+6. **Read output**: `herdr agent read <name> --source recent-unwrapped --lines 120`
+7. **Wait for completion**: `herdr agent wait <name> --timeout 120000`
+
+## Prohibited
+
+- Running git commands directly
+- Editing files directly
+- Making commits yourself
+- Using `bash` or `edit` tools for work tasks
+
+## Allowed
+
+- Using Herdr CLI to inspect state (`herdr agent list`, `herdr pane list`)
+- Waiting for agents (`herdr agent wait`)
+- Reading agent output (`herdr agent read`)
+- Splitting panes and starting agents


### PR DESCRIPTION
## Summary

Changes OpenCode's `default_agent` from `plan` to `build` so that Herdr-launched agents start in build mode (full permissions).

## Changes

1. **`default_agent: build`** — Herdr worktrees now use build mode by default. You can still switch to plan mode with `Tab` or `@plan` in the TUI.

2. **Herdr agent workflow rule** — New rule file that enforces using Herdr agents for work when `HERDR_ENV=1`. Prevents manual git/file edits inside worktrees.

## Motivation

When Herdr launches opencode agents, they should have full build permissions to complete tasks autonomously. Plan mode requires manual approval for every file edit and bash command, which defeats the purpose of agent orchestration in Herdr.

For manual TUI use, you can still switch to plan mode with `Tab` or use `@plan` subagent.